### PR TITLE
Alt RU layout

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="input_subtype_en_US">English (US)</string>
     <string name="input_subtype_ru_RU_BB_Passport">Русский (BB Passport)</string>
     <string name="input_subtype_ru_RU_Transliterate">Русский (Транслит)</string>
+    <string name="input_subtype_ru_RU_Alt">Русский (Alt)</string>
 
     <string name="voice_ime_not_configured">Voice input not configured</string>
     <string name="keyboard_mapping_load_failed">Couldn\'t load keyboard mapping</string>

--- a/app/src/main/res/xml/keyboard_mapping_ru_alt.xml
+++ b/app/src/main/res/xml/keyboard_mapping_ru_alt.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<KeyboardMapping>
+    <Key code="45" shiftValue="Й" value="й">
+        <Alt value="0" />
+    </Key>
+    <Key code="51" shiftValue="Ц" value="ц">
+        <Alt value="1" />
+    </Key>
+    <Key code="33" shiftValue="У" value="у">
+        <Alt value="2" />
+        <Alt value="\@" />
+    </Key>
+    <Key code="46" shiftValue="К" value="к">
+        <Alt value="3" />
+        <Alt value="\#" />
+    </Key>
+    <Key code="48" shiftValue="Е" value="е">
+        <Add shiftValue="Ё" value="ё" />
+        <Alt value="(" />
+        <Alt value="{" />
+        <Alt value="[" />
+        <Alt value="&lt;" />
+    </Key>
+    <Key code="53" shiftValue="Н" value="н">
+        <Alt value=")" />
+        <Alt value="}" />
+        <Alt value="]" />
+        <Alt value=">" />
+    </Key>
+    <Key code="49" shiftValue="Г" value="г">
+        <Alt value="-" />
+        <Alt value="~" />
+    </Key>
+    <Key code="37" shiftValue="Ш" value="ш">
+        <Add shiftValue="Щ" value="щ" />
+        <Alt value="_" />
+    </Key>
+    <Key code="43" shiftValue="З" value="з">
+        <Alt value="/" />
+        <Alt value="\\" />
+        <Alt value="|" />
+    </Key>
+    <Key code="44" shiftValue="Х" value="х">
+        <Add shiftValue="Ь" value="ь" />
+        <Alt value=":" />
+        <Alt value=";" />
+    </Key>
+    <Key code="29" shiftValue="Ф" value="ф">
+        <Alt value="\@" />
+    </Key>
+    <Key code="47" shiftValue="Ы" value="ы">
+        <Add shiftValue="Ъ" value="ъ" />
+        <Alt value="4" />
+        <Alt value="$" />
+        <Alt value="€" />
+        <Alt value="¥" />
+        <Alt value="₽" />
+    </Key>
+    <Key code="32" shiftValue="В" value="в">
+        <Alt value="5" />
+        <Alt value="%" />
+    </Key>
+    <Key code="34" shiftValue="А" value="а">
+        <Alt value="6" />
+        <Alt value="^" />
+    </Key>
+    <Key code="35" shiftValue="П" value="п">
+        <Alt value="*" />
+    </Key>
+    <Key code="36" shiftValue="Р" value="р">
+        <Alt value="\#" />
+        <Alt value="№" />
+    </Key>
+    <Key code="38" shiftValue="О" value="о">
+        <Alt value="+" />
+        <Alt value="=" />
+        <Alt value="≈" />
+        <Alt value="±" />
+    </Key>
+    <Key code="39" shiftValue="Л" value="л">
+        <Alt value="&quot;" />
+        <Alt value="«" />
+        <Alt value="»" />
+    </Key>
+    <Key code="40" shiftValue="Д" value="д">
+        <Add shiftValue="Ж" value="ж" />
+        <Alt value="'" />
+        <Alt value="`" />
+    </Key>
+    <Key code="54" shiftValue="Я" value="я">
+        <Add shiftValue="Э" value="э" />
+        <Alt value="!" />
+    </Key>
+    <Key code="52" shiftValue="Ч" value="ч">
+        <Alt value="7" />
+        <Alt value="&amp;" />
+    </Key>
+    <Key code="31" shiftValue="С" value="с">
+        <Alt value="8" />
+        <Alt value="*" />
+    </Key>
+    <Key code="50" shiftValue="М" value="м">
+        <Alt value="9" />
+    </Key>
+    <Key code="30" shiftValue="И" value="и">
+        <Alt value="." />
+    </Key>
+    <Key code="42" shiftValue="Т" value="т">
+        <Alt value="," />
+    </Key>
+    <Key code="41" shiftValue="Б" value="б">
+        <Add shiftValue="Ю" value="ю" />
+        <Alt value="\?" />
+    </Key>
+</KeyboardMapping>

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -32,4 +32,13 @@
         android:isAsciiCapable="false"
         android:imeSubtypeExtraValue="DisplayTag=ru,KeyboardMapping=ru_t,EmojiCapable" />
 
+    <subtype
+        android:label="@string/input_subtype_ru_RU_Alt"
+        android:subtypeId="0x04"
+        android:imeSubtypeLocale="ru"
+        android:languageTag="ru"
+        android:imeSubtypeMode="keyboard"
+        android:isAsciiCapable="false"
+        android:imeSubtypeExtraValue="DisplayTag=ru,KeyboardMapping=ru_alt,EmojiCapable" />
+
 </input-method>


### PR DESCRIPTION
For me BB Passport layout is not convinient because almost all keys are shifted from their positions on QWERTY keyboard,  
so I've tried to develope something more similar to PC layout.

All keys are where I used to see them on PC keyboard, with some sacrifices due to Titan Pocket limitations:  
- Д, Ж are on the same key, which is probably inconvinient, but my goal here is to avoid any shifting of other key  
- Б, Ю are on the same key for the same reason  
- Х, Ь - same   

And of course the "no shift" rule has some exceptions:  

- Ш and Щ are on the same key  
- Э is placed with Я  
- Ъ is placed with Ы (it should be with Х but it's rare enough to occupy such convinient place)

Also I've added/moved some symbol keys to num keys, again positions are similar to PC keyboard.

Unfortunately I have no experience in building Android apps, so probably I've not adjusted all code properly  
to enable new layout and also I haven't tried to build this app (though I've tried to modify it with `apktool` but no luck).

I really hope you'll find some time to add this layout, maybe it will be useful for someone else too.
